### PR TITLE
Create TypeScript AgentMaster orchestration prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,11 @@ coverage.*
 *.coverprofile
 profile.cov
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Dependency directories
+node_modules/
+
+# Build output
+dist/
 
 # Go workspace file
 go.work

--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
-# basic-agent
+# AgentMaster (TypeScript Edition)
+
+AgentMaster is a modular multi-agent system prototype built with TypeScript and an Express-style HTTP layer. The system mirrors the architecture described in the project brief: a conversational UI funnels requests to a coordinator that orchestrates multiple specialized agents (SQL, information retrieval, and vision) through Agent-to-Agent (A2A) messaging and a lightweight implementation of the Model Context Protocol (MCP).
+
+> **Offline note**: The execution environment blocks external npm installs. To keep the prototype operational, a minimal Express-compatible server (`src/lib/miniExpress.ts`) is bundled in the repo. It exposes the subset of Express APIs used here (`use`, `get`, `post`, `listen`, `express.json`, `express.static`). Replacing it with the official package only requires adjusting the import.
+
+## High-level architecture
+
+```
+┌─────────────┐      ┌────────────────────┐      ┌────────────────┐
+│  Web UI     │ ---> │ Express-like Layer │ ---> │ Coordinator    │
+│ (public/)   │      │  (TypeScript)      │      │   Agent        │
+└─────────────┘      └────────────────────┘      └────────────────┘
+                                                     │
+                                 ┌───────────────────┴───────────────────┐
+                                 │                                       │
+                         ┌───────────────┐                       ┌───────────────┐
+                         │   Protocols   │                       │   State Layer │
+                         │ (A2A + MCP)   │                       │ (memory/cache)│
+                         └───────────────┘                       └───────────────┘
+                                 │                                       │
+                 ┌───────────────┴───────────────┐         ┌────────────┴────────────┐
+                 │        Agent Clients          │         │     LLM Synthesis       │
+                 └───────────────┬───────────────┘         └────────────┬────────────┘
+                                 │                                       │
+                      ┌──────────┴──────────┐                    ┌───────┴─────────┐
+                      │ Domain MCP Servers  │                    │  Response Draft │
+                      │ SQL / IR / Vision   │                    │ (LLM Module)    │
+                      └─────────────────────┘                    └────────────────┘
+```
+
+### Components
+
+- **UI layer**: `public/index.html` provides a single-page conversational console. It displays assistant replies, debugging transcripts (A2A log, retrieved memories, agent results), and sends `/api/message` requests.
+- **HTTP layer**: `src/index.ts` wires the Express-like server, static hosting, health check, and message endpoint.
+- **Coordinator Agent**: `src/layers/agents/CoordinatorAgent.ts` evaluates task complexity, plans workflows, dispatches tasks via `AgentClient`, aggregates results, consults memory, and calls the LLM synthesizer.
+- **Protocol layer**:
+  - `src/layers/protocols/A2AProtocol.ts`: in-memory transcript of agent-to-agent messages.
+  - `src/layers/protocols/MCPProtocol.ts`: JSON-RPC server/client implementation for tool calls.
+- **State layer**: `src/layers/state/StateManager.ts` combines an in-memory vector database (hash-bucket embeddings + cosine similarity) and a session context cache (history + scratchpad).
+- **Agents**: Located under `src/layers/agents/`.
+  - `SQLAgent`: executes structured queries against demo tables.
+  - `IRAgent`: ranks small knowledge documents with keyword overlap.
+  - `ImageAgent`: stubs integration with an external vision API.
+  - `GeneralAgent`: open-domain fallback using the bundled LLM module.
+- **Agent clients**: `src/layers/clients/AgentClient.ts` bridges A2A and MCP for each agent, logging dispatch/completion events and merging JSON-RPC results with agent summaries.
+- **LLM module**: `src/layers/llm/LLMModule.ts` emulates GPT-4o-mini behavior for synthesis, formatting agent outputs, memories, and conversation snippets into a final Markdown answer.
+
+## Data flow (text requests)
+
+1. The UI sends `{ sessionId, text }` to `/api/message`.
+2. The server forwards the payload to the coordinator.
+3. The coordinator logs the user message, recalls semantic memories, and determines intents/complexity.
+4. Planned tasks are executed through MCP-wrapped agents. Agent-to-agent messages record dispatch/completion.
+5. Results and retrieved memories feed the LLM module, which crafts a synthesized Markdown reply.
+6. The coordinator stores the new memory, updates the session context, and returns the structured response to the UI.
+
+Image payloads trigger the `image.process` task and are routed to the vision agent (stub). Multiple intents in a single message upgrade the workflow to "complex" orchestration.
+
+## Getting started
+
+```bash
+# Build the TypeScript sources
+npm run build
+
+# Start the server (listens on port 3000 by default)
+npm start
+```
+
+Then open `http://localhost:3000` to try the conversational console. The debug drawer shows which agents were invoked, the MCP transcript, and any semantic memory hits.
+
+## Project structure
+
+```
+public/                # Conversational UI
+src/
+  index.ts             # Express-like bootstrap + routing
+  lib/miniExpress.ts   # Offline-friendly Express subset
+  layers/
+    agents/
+      CoordinatorAgent.ts
+      GeneralAgent.ts
+      domain/
+        SQLAgent.ts
+        IRAgent.ts
+        ImageAgent.ts
+    clients/
+      AgentClient.ts
+    llm/
+      LLMModule.ts
+    protocols/
+      A2AProtocol.ts
+      MCPProtocol.ts
+    state/
+      StateManager.ts
+```
+
+## Next steps / extensions
+
+- Swap `miniExpress` with the official Express package once npm access is restored.
+- Replace the stubbed LLM module with actual GPT-4o mini invocations and integrate G-Eval scoring.
+- Expand MCP tooling with additional domain agents and persistence-backed vector stores.
+- Parallelize agent execution and add richer error recovery / retry strategies in the coordinator.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "agentmaster",
+  "version": "1.0.0",
+  "description": "AgentMaster multi-agent orchestration prototype with Express and TypeScript",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "keywords": [
+    "agents",
+    "express",
+    "typescript",
+    "multi-agent"
+  ],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AgentMaster Console</title>
+    <style>
+      :root {
+        color-scheme: dark light;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+
+      body {
+        margin: 0;
+        display: flex;
+        min-height: 100vh;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at top, rgba(56, 189, 248, 0.1), transparent 55%),
+          #020617;
+      }
+
+      .chat-shell {
+        width: min(960px, 92vw);
+        height: min(640px, 90vh);
+        background: rgba(15, 23, 42, 0.92);
+        border-radius: 24px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 30px 60px -15px rgba(15, 23, 42, 0.8);
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        overflow: hidden;
+      }
+
+      header {
+        padding: 24px 28px 16px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 1.4rem;
+      }
+
+      header p {
+        margin: 6px 0 0;
+        font-size: 0.95rem;
+        color: rgba(226, 232, 240, 0.72);
+      }
+
+      #messages {
+        padding: 20px 28px;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .message {
+        padding: 16px 18px;
+        border-radius: 18px;
+        line-height: 1.55;
+        white-space: pre-line;
+        background: rgba(30, 41, 59, 0.88);
+        border: 1px solid rgba(148, 163, 184, 0.15);
+      }
+
+      .message.user {
+        align-self: flex-end;
+        background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(14, 165, 233, 0.9));
+        color: #f8fafc;
+        box-shadow: 0 8px 25px -12px rgba(37, 99, 235, 0.8);
+      }
+
+      .message.assistant {
+        align-self: flex-start;
+      }
+
+      footer {
+        padding: 18px 24px 22px;
+        border-top: 1px solid rgba(148, 163, 184, 0.18);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        background: rgba(15, 23, 42, 0.96);
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 80px;
+        resize: vertical;
+        padding: 14px 16px;
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.85);
+        color: inherit;
+        font: inherit;
+        line-height: 1.4;
+      }
+
+      textarea:focus {
+        outline: 2px solid rgba(56, 189, 248, 0.4);
+        border-color: rgba(56, 189, 248, 0.4);
+      }
+
+      .actions {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+      }
+
+      button {
+        padding: 12px 24px;
+        border-radius: 999px;
+        border: none;
+        font-weight: 600;
+        background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(14, 165, 233, 0.95));
+        color: #f8fafc;
+        cursor: pointer;
+        box-shadow: 0 12px 25px -12px rgba(56, 189, 248, 0.6);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 16px 32px -16px rgba(56, 189, 248, 0.7);
+      }
+
+      .status-line {
+        font-size: 0.85rem;
+        color: rgba(226, 232, 240, 0.65);
+      }
+
+      details {
+        background: rgba(30, 41, 59, 0.65);
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 12px 16px;
+        color: rgba(226, 232, 240, 0.9);
+      }
+
+      summary {
+        cursor: pointer;
+        font-weight: 600;
+      }
+
+      code {
+        font-family: 'JetBrains Mono', 'Fira Code', monospace;
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="chat-shell">
+      <header>
+        <h1>AgentMaster</h1>
+        <p>Unified conversational hub orchestrating SQL, IR, and Vision agents via MCP + A2A.</p>
+      </header>
+      <div id="messages"></div>
+      <footer>
+        <textarea id="prompt" placeholder="Ask something—mix SQL, documents, or images." autofocus></textarea>
+        <div class="actions">
+          <div class="status-line" id="status">Idle</div>
+          <button id="send">Send</button>
+        </div>
+        <details id="debug-panel">
+          <summary>Debug transcript</summary>
+          <pre id="debug"></pre>
+        </details>
+      </footer>
+    </div>
+    <script>
+      const sessionId = crypto.randomUUID();
+      const messagesEl = document.getElementById('messages');
+      const promptEl = document.getElementById('prompt');
+      const sendButton = document.getElementById('send');
+      const statusEl = document.getElementById('status');
+      const debugEl = document.getElementById('debug');
+
+      function appendMessage(role, content) {
+        const bubble = document.createElement('div');
+        bubble.className = `message ${role}`;
+        bubble.textContent = content;
+        messagesEl.appendChild(bubble);
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+      }
+
+      async function sendMessage() {
+        const text = promptEl.value.trim();
+        if (!text) {
+          return;
+        }
+
+        appendMessage('user', text);
+        promptEl.value = '';
+        statusEl.textContent = 'Thinking…';
+        sendButton.disabled = true;
+
+        try {
+          const response = await fetch('/api/message', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sessionId, text })
+          });
+
+          if (!response.ok) {
+            throw new Error('Request failed');
+          }
+
+          const payload = await response.json();
+          appendMessage('assistant', payload.answer);
+
+          debugEl.textContent = JSON.stringify(
+            {
+              a2aTranscript: payload.a2aTranscript,
+              retrievedMemories: payload.retrievedMemories,
+              agentResults: payload.agentResults
+            },
+            null,
+            2
+          );
+          statusEl.textContent = 'Response ready';
+        } catch (error) {
+          appendMessage('assistant', 'Something went wrong while contacting the coordinator.');
+          statusEl.textContent = 'Error';
+          console.error(error);
+        } finally {
+          sendButton.disabled = false;
+        }
+      }
+
+      sendButton.addEventListener('click', sendMessage);
+      promptEl.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+          sendMessage();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,46 @@
+import path from 'path';
+import express from './lib/miniExpress';
+import { CoordinatorAgent } from './layers/agents/CoordinatorAgent';
+
+const app = express();
+const coordinator = new CoordinatorAgent();
+const port = Number(process.env.PORT ?? 3000);
+
+app.use(express.json());
+app.use(express.static(path.resolve(process.cwd(), 'public')));
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok', timestamp: Date.now() });
+});
+
+app.post('/api/message', async (req, res) => {
+  const { sessionId, text, imageBase64, imagePrompt } = (req.body ?? {}) as {
+    sessionId?: string;
+    text?: string;
+    imageBase64?: string;
+    imagePrompt?: string;
+  };
+
+  if (!sessionId) {
+    res.status(400).json({ error: 'sessionId is required' });
+    return;
+  }
+
+  try {
+    const response = await coordinator.handleUserInput({
+      sessionId,
+      text,
+      imageBase64,
+      imagePrompt
+    });
+
+    res.json(response);
+  } catch (error) {
+    console.error('Failed to process message', error);
+    res.status(500).json({ error: 'Failed to process message', details: (error as Error).message });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`AgentMaster server listening on port ${port}`);
+});

--- a/src/layers/agents/BaseAgent.ts
+++ b/src/layers/agents/BaseAgent.ts
@@ -1,0 +1,62 @@
+import { MCPServer, ProcedureHandler } from '../protocols/MCPProtocol';
+
+export interface AgentProfile {
+  id: string;
+  name: string;
+  description: string;
+  capabilities: string[];
+}
+
+export interface AgentTask<TPayload = unknown> {
+  type: string;
+  payload: TPayload;
+  context?: Record<string, unknown>;
+}
+
+export interface AgentResult<TResult = unknown> {
+  agentId: string;
+  agentName: string;
+  type: string;
+  summary: string;
+  result: TResult;
+  metadata?: Record<string, unknown>;
+}
+
+export abstract class BaseAgent {
+  protected readonly server = new MCPServer();
+
+  protected constructor(protected readonly profile: AgentProfile) {
+    this.registerProcedures();
+  }
+
+  get id(): string {
+    return this.profile.id;
+  }
+
+  get name(): string {
+    return this.profile.name;
+  }
+
+  get description(): string {
+    return this.profile.description;
+  }
+
+  get capabilities(): string[] {
+    return this.profile.capabilities;
+  }
+
+  get mcpServer(): MCPServer {
+    return this.server;
+  }
+
+  protected registerProcedure<TParams, TResult>(
+    name: string,
+    handler: ProcedureHandler<TParams, TResult>
+  ): void {
+    this.server.registerProcedure(name, handler);
+  }
+
+  protected abstract registerProcedures(): void;
+
+  abstract handleTask(task: AgentTask): Promise<AgentResult>;
+}

--- a/src/layers/agents/CoordinatorAgent.ts
+++ b/src/layers/agents/CoordinatorAgent.ts
@@ -1,0 +1,220 @@
+import { A2AProtocol, AgentEnvelope } from '../protocols/A2AProtocol';
+import { AgentClient } from '../clients/AgentClient';
+import { AgentResult, AgentTask } from './BaseAgent';
+import { SQLAgent } from './domain/SQLAgent';
+import { IRAgent } from './domain/IRAgent';
+import { ImageAgent } from './domain/ImageAgent';
+import { GeneralAgent } from './GeneralAgent';
+import { MCPClient } from '../protocols/MCPProtocol';
+import { StateManager, RetrievedMemory, SessionContext } from '../state/StateManager';
+import { LLMModule } from '../llm/LLMModule';
+
+export interface UserInput {
+  sessionId: string;
+  text?: string;
+  imageBase64?: string;
+  imagePrompt?: string;
+}
+
+export interface CoordinatorResponse {
+  answer: string;
+  agentResults: AgentResult[];
+  a2aTranscript: AgentEnvelope[];
+  retrievedMemories: RetrievedMemory[];
+  sessionContext: SessionContext;
+}
+
+export class CoordinatorAgent {
+  private readonly protocol = new A2AProtocol();
+  private readonly stateManager: StateManager;
+  private readonly llm: LLMModule;
+  private readonly agentRegistry = new Map<string, AgentClient>();
+
+  constructor() {
+    this.stateManager = new StateManager();
+    this.llm = new LLMModule({ model: 'gpt-4o-mini', temperature: 0.3 });
+    this.registerAgents();
+  }
+
+  async handleUserInput(input: UserInput): Promise<CoordinatorResponse> {
+    const { sessionId } = input;
+    const userContent = input.text ?? '[image query]';
+
+    this.stateManager.appendMessage(sessionId, {
+      role: 'user',
+      content: userContent,
+      timestamp: Date.now()
+    });
+
+    const detectedIntents = this.detectIntents(input);
+    const complexity = this.evaluateComplexity(userContent, detectedIntents);
+    const tasks = this.planTasks(input, detectedIntents, complexity);
+
+    const retrievedMemories = this.stateManager.recallMemories(userContent, 3);
+    this.stateManager.updateScratchpad(sessionId, {
+      lastDetectedIntents: detectedIntents,
+      complexity
+    });
+
+    const agentResults: AgentResult[] = [];
+    const conversationId = `${sessionId}-${Date.now()}`;
+
+    for (const task of tasks) {
+      const client = this.agentRegistry.get(task.type);
+      if (!client) {
+        continue;
+      }
+
+      try {
+        const result = await client.execute(task, conversationId);
+        agentResults.push(result);
+      } catch (error) {
+        agentResults.push({
+          agentId: 'coordinator',
+          agentName: 'Coordinator',
+          type: task.type,
+          summary: 'Task failed during orchestration.',
+          result: {
+            error: (error as Error).message
+          }
+        });
+      }
+    }
+
+    if (agentResults.length === 0) {
+      const fallbackClient = this.agentRegistry.get('general.answer');
+      if (fallbackClient) {
+        const result = await fallbackClient.execute(
+          {
+            type: 'general.answer',
+            payload: {
+              question: userContent,
+              context: 'Fallback execution because no domain agents ran.'
+            }
+          },
+          conversationId
+        );
+        agentResults.push(result);
+      }
+    }
+
+    const sessionContext = this.stateManager.getSessionContext(sessionId);
+    const synthesized = this.llm.synthesize(userContent, agentResults, sessionContext, retrievedMemories);
+
+    this.stateManager.appendMessage(sessionId, {
+      role: 'assistant',
+      content: synthesized,
+      timestamp: Date.now()
+    });
+
+    this.stateManager.storeMemory(userContent, {
+      sessionId,
+      complexity,
+      agents: agentResults.map((result) => result.agentId)
+    });
+
+    return {
+      answer: synthesized,
+      agentResults,
+      a2aTranscript: this.protocol.history({ conversationId }),
+      retrievedMemories,
+      sessionContext
+    };
+  }
+
+  private registerAgents(): void {
+    const sqlAgent = new SQLAgent();
+    const irAgent = new IRAgent();
+    const imageAgent = new ImageAgent();
+    const generalAgent = new GeneralAgent(this.llm);
+
+    this.agentRegistry.set('sql.query', this.createClient(sqlAgent));
+    this.agentRegistry.set('ir.retrieve', this.createClient(irAgent));
+    this.agentRegistry.set('image.process', this.createClient(imageAgent));
+    this.agentRegistry.set('general.answer', this.createClient(generalAgent));
+  }
+
+  private createClient(agent: SQLAgent | IRAgent | ImageAgent | GeneralAgent): AgentClient {
+    const client = new MCPClient(agent.mcpServer, agent.id);
+    return new AgentClient(agent, this.protocol, client);
+  }
+
+  private detectIntents(input: UserInput): string[] {
+    const text = (input.text ?? '').toLowerCase();
+    const intents = new Set<string>();
+
+    if (/(sql|database|table|query)/.test(text)) {
+      intents.add('sql.query');
+    }
+
+    if (/(document|knowledge|article|research|context)/.test(text)) {
+      intents.add('ir.retrieve');
+    }
+
+    if (input.imageBase64 || /(image|picture|vision|photo)/.test(text)) {
+      intents.add('image.process');
+    }
+
+    if (intents.size === 0) {
+      intents.add('general.answer');
+    }
+
+    return Array.from(intents);
+  }
+
+  private evaluateComplexity(message: string, intents: string[]): 'simple' | 'complex' {
+    const tokenCount = message.trim().split(/\s+/).filter(Boolean).length;
+    const hasCoordinator = /(and|then|combine|together|also|pipeline|workflow)/i.test(message);
+    return intents.length > 1 || tokenCount > 20 || hasCoordinator ? 'complex' : 'simple';
+  }
+
+  private planTasks(
+    input: UserInput,
+    intents: string[],
+    complexity: 'simple' | 'complex'
+  ): AgentTask[] {
+    if (complexity === 'simple') {
+      const primaryIntent = intents[0] ?? 'general.answer';
+      return [this.createTask(primaryIntent, input)];
+    }
+
+    return intents.map((intent) => this.createTask(intent, input));
+  }
+
+  private createTask(intent: string, input: UserInput): AgentTask {
+    switch (intent) {
+      case 'sql.query':
+        return {
+          type: 'sql.query',
+          payload: {
+            query: input.text ?? 'SELECT * FROM sales'
+          }
+        };
+      case 'ir.retrieve':
+        return {
+          type: 'ir.retrieve',
+          payload: {
+            query: input.text ?? 'Retrieve relevant documents'
+          }
+        };
+      case 'image.process':
+        return {
+          type: 'image.process',
+          payload: {
+            imageData: input.imageBase64,
+            prompt: input.imagePrompt ?? input.text,
+            operation: 'describe'
+          }
+        };
+      case 'general.answer':
+      default:
+        return {
+          type: 'general.answer',
+          payload: {
+            question: input.text ?? 'Provide a helpful response',
+            context: input.imageBase64 ? 'Image provided by the user.' : undefined
+          }
+        };
+    }
+  }
+}

--- a/src/layers/agents/GeneralAgent.ts
+++ b/src/layers/agents/GeneralAgent.ts
@@ -1,0 +1,56 @@
+import { BaseAgent, AgentResult, AgentTask } from './BaseAgent';
+import { LLMModule } from '../llm/LLMModule';
+
+interface GeneralQueryPayload {
+  question: string;
+  context?: string;
+}
+
+interface GeneralAnswer {
+  answer: string;
+  reasoning: string;
+}
+
+export class GeneralAgent extends BaseAgent {
+  constructor(private readonly llm: LLMModule) {
+    super({
+      id: 'general-agent',
+      name: 'Generalist Agent',
+      description: 'Handles open-domain queries and acts as a fallback responder.',
+      capabilities: ['open-domain', 'fallback', 'summarization']
+    });
+  }
+
+  protected registerProcedures(): void {
+    this.registerProcedure<GeneralQueryPayload, GeneralAnswer>('answerQuestion', (payload) => {
+      return this.produceAnswer(payload);
+    });
+  }
+
+  async handleTask(task: AgentTask<GeneralQueryPayload>): Promise<AgentResult<GeneralAnswer>> {
+    const result = this.produceAnswer(task.payload);
+
+    return {
+      agentId: this.id,
+      agentName: this.name,
+      type: task.type,
+      summary: 'Generated open-domain response with fallback logic.',
+      result,
+      metadata: {
+        question: task.payload.question
+      }
+    };
+  }
+
+  private produceAnswer(payload: GeneralQueryPayload): GeneralAnswer {
+    const answer = this.llm.generateResponse(payload.question, {
+      context: payload.context,
+      agent: this.name
+    });
+
+    return {
+      answer,
+      reasoning: 'Generated using the configured LLM module with provided context.'
+    };
+  }
+}

--- a/src/layers/agents/domain/IRAgent.ts
+++ b/src/layers/agents/domain/IRAgent.ts
@@ -1,0 +1,98 @@
+import { BaseAgent, AgentResult, AgentTask } from '../BaseAgent';
+
+interface RetrievalPayload {
+  query: string;
+  topK?: number;
+}
+
+interface KnowledgeDocument {
+  id: string;
+  title: string;
+  content: string;
+  tags: string[];
+}
+
+interface RetrievalResult {
+  documents: KnowledgeDocument[];
+  reasoning: string;
+}
+
+export class IRAgent extends BaseAgent {
+  private readonly knowledgeBase: KnowledgeDocument[] = [
+    {
+      id: 'doc-1',
+      title: 'Vector Databases Overview',
+      content:
+        'Vector databases index embeddings to enable similarity search for semantic retrieval and contextual memory.',
+      tags: ['vectors', 'retrieval', 'memory']
+    },
+    {
+      id: 'doc-2',
+      title: 'A2A Protocol Design Notes',
+      content:
+        'Agent-to-agent (A2A) messaging enables delegation, progress tracking, and coordination across specialized workers.',
+      tags: ['protocols', 'coordination']
+    },
+    {
+      id: 'doc-3',
+      title: 'MCP JSON-RPC Primer',
+      content:
+        'The Model Context Protocol (MCP) exposes tools, context, and memory through JSON-RPC endpoints backed by caches.',
+      tags: ['mcp', 'tooling']
+    }
+  ];
+
+  constructor() {
+    super({
+      id: 'ir-agent',
+      name: 'IR Agent',
+      description: 'Retrieves passages from unstructured knowledge bases.',
+      capabilities: ['retrieval', 'knowledge-base', 'semantic-search']
+    });
+  }
+
+  protected registerProcedures(): void {
+    this.registerProcedure<RetrievalPayload, RetrievalResult>('retrieveDocuments', (payload) => {
+      const documents = this.rankDocuments(payload.query, payload.topK ?? 2);
+
+      return {
+        documents,
+        reasoning: `Selected ${documents.length} document(s) using keyword overlap scoring.`
+      };
+    });
+  }
+
+  async handleTask(task: AgentTask<RetrievalPayload>): Promise<AgentResult<RetrievalResult>> {
+    const documents = this.rankDocuments(task.payload.query, task.payload.topK ?? 3);
+
+    return {
+      agentId: this.id,
+      agentName: this.name,
+      type: task.type,
+      summary: `Retrieved ${documents.length} relevant knowledge document(s).`,
+      result: {
+        documents,
+        reasoning: 'Keyword overlap scoring using a simple bag-of-words heuristic.'
+      },
+      metadata: {
+        query: task.payload.query
+      }
+    };
+  }
+
+  private rankDocuments(query: string, topK: number): KnowledgeDocument[] {
+    const keywords = query.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+
+    const scored = this.knowledgeBase.map((doc) => {
+      const haystack = `${doc.title} ${doc.content} ${doc.tags.join(' ')}`.toLowerCase();
+      const score = keywords.reduce((acc, term) => (haystack.includes(term) ? acc + 1 : acc), 0);
+      return { doc, score };
+    });
+
+    return scored
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK)
+      .map((entry) => entry.doc);
+  }
+}

--- a/src/layers/agents/domain/ImageAgent.ts
+++ b/src/layers/agents/domain/ImageAgent.ts
@@ -1,0 +1,69 @@
+import { BaseAgent, AgentResult, AgentTask } from '../BaseAgent';
+
+interface ImagePayload {
+  imageData?: string;
+  prompt?: string;
+  operation: 'describe' | 'classify' | 'tag';
+}
+
+interface ImageResult {
+  observations: string[];
+  notes: string;
+}
+
+export class ImageAgent extends BaseAgent {
+  constructor() {
+    super({
+      id: 'image-agent',
+      name: 'Image Agent',
+      description: 'Interfaces with vision APIs for captioning, tagging, and classification.',
+      capabilities: ['vision', 'captioning', 'classification']
+    });
+  }
+
+  protected registerProcedures(): void {
+    this.registerProcedure<ImagePayload, ImageResult>('processImage', (payload) => {
+      return this.simulateVision(payload);
+    });
+  }
+
+  async handleTask(task: AgentTask<ImagePayload>): Promise<AgentResult<ImageResult>> {
+    const result = this.simulateVision(task.payload);
+
+    return {
+      agentId: this.id,
+      agentName: this.name,
+      type: task.type,
+      summary: 'Processed image task via simulated vision pipeline.',
+      result,
+      metadata: {
+        prompt: task.payload.prompt,
+        operation: task.payload.operation
+      }
+    };
+  }
+
+  private simulateVision(payload: ImagePayload): ImageResult {
+    const baseObservations = [
+      'Detected shapes and color palette indicative of a concept illustration.',
+      'No OCR text extraction performed in the offline prototype.'
+    ];
+
+    if (payload.operation === 'classify') {
+      baseObservations.push('Predicted label: synthetic-demo-object (confidence 0.42).');
+    }
+
+    if (payload.operation === 'tag') {
+      baseObservations.push('Generated tags: prototype, vision, agent-master.');
+    }
+
+    if (payload.prompt) {
+      baseObservations.push(`Applied user prompt: ${payload.prompt}`);
+    }
+
+    return {
+      observations: baseObservations,
+      notes: 'Stub implementation that stands in for an external vision API call.'
+    };
+  }
+}

--- a/src/layers/agents/domain/SQLAgent.ts
+++ b/src/layers/agents/domain/SQLAgent.ts
@@ -1,0 +1,101 @@
+import { BaseAgent, AgentResult, AgentTask } from '../BaseAgent';
+import { MCPError } from '../../protocols/MCPProtocol';
+
+interface SqlQueryPayload {
+  query: string;
+}
+
+interface TableRow {
+  [column: string]: string | number;
+}
+
+interface SqlExecutionResult {
+  rows: TableRow[];
+  explanation: string;
+}
+
+interface SqlTableStore {
+  employees: TableRow[];
+  sales: TableRow[];
+}
+
+export class SQLAgent extends BaseAgent {
+  private readonly tables: SqlTableStore = {
+    employees: [
+      { id: 1, name: 'Aria', role: 'Researcher', location: 'Berlin' },
+      { id: 2, name: 'Noah', role: 'Engineer', location: 'Paris' },
+      { id: 3, name: 'Liam', role: 'Designer', location: 'London' }
+    ],
+    sales: [
+      { id: 101, region: 'EMEA', revenue: 125000 },
+      { id: 102, region: 'Americas', revenue: 174500 },
+      { id: 103, region: 'APAC', revenue: 98000 }
+    ]
+  };
+
+  constructor() {
+    super({
+      id: 'sql-agent',
+      name: 'SQL Agent',
+      description: 'Executes SQL-style analytics over structured datasets.',
+      capabilities: ['sql', 'analytics', 'tabular-reasoning']
+    });
+  }
+
+  protected registerProcedures(): void {
+    this.registerProcedure<SqlQueryPayload, SqlExecutionResult>('executeSQL', ({ query }) => {
+      if (!query?.trim()) {
+        throw new MCPError('SQL query cannot be empty', 400);
+      }
+
+      return this.simulateQuery(query);
+    });
+  }
+
+  async handleTask(task: AgentTask<SqlQueryPayload>): Promise<AgentResult<SqlExecutionResult>> {
+    const result = await this.simulateQuery(task.payload.query);
+
+    return {
+      agentId: this.id,
+      agentName: this.name,
+      type: task.type,
+      summary: `SQL execution completed with ${result.rows.length} row(s).`,
+      result,
+      metadata: {
+        query: task.payload.query
+      }
+    };
+  }
+
+  private simulateQuery(query: string): SqlExecutionResult {
+    const normalized = query.toLowerCase();
+
+    if (normalized.includes('from employees')) {
+      return {
+        rows: this.tables.employees,
+        explanation: 'Retrieved employee roster with roles and locations.'
+      };
+    }
+
+    if (normalized.includes('from sales')) {
+      const totalRevenue = this.tables.sales.reduce((sum, row) => sum + Number(row.revenue), 0);
+
+      if (normalized.includes('sum') || normalized.includes('total')) {
+        return {
+          rows: [{ totalRevenue }],
+          explanation: 'Aggregated total revenue across sales regions.'
+        };
+      }
+
+      return {
+        rows: this.tables.sales,
+        explanation: 'Returned sales revenue by region.'
+      };
+    }
+
+    return {
+      rows: [],
+      explanation: 'No matching in-memory dataset found for the provided SQL statement.'
+    };
+  }
+}

--- a/src/layers/clients/AgentClient.ts
+++ b/src/layers/clients/AgentClient.ts
@@ -1,0 +1,64 @@
+import { AgentTask, AgentResult, BaseAgent } from '../agents/BaseAgent';
+import { MCPClient } from '../protocols/MCPProtocol';
+import { A2AProtocol } from '../protocols/A2AProtocol';
+
+export class AgentClient {
+  constructor(
+    private readonly agent: BaseAgent,
+    private readonly protocol: A2AProtocol,
+    private readonly client: MCPClient
+  ) {}
+
+  async execute(task: AgentTask, conversationId: string): Promise<AgentResult> {
+    this.protocol.sendMessage(
+      this.protocol.createMessage('coordinator', this.agent.id, conversationId, `Dispatching ${task.type}`)
+    );
+
+    try {
+      const method = this.resolveMethod(task.type);
+      const rpcResult = await this.client.call(method, task.payload);
+      const agentResult = await this.agent.handleTask(task);
+      agentResult.metadata = {
+        ...(agentResult.metadata ?? {}),
+        rpcMethod: method,
+        rpcEcho: rpcResult
+      };
+
+      this.protocol.sendMessage(
+        this.protocol.createMessage(
+          this.agent.id,
+          'coordinator',
+          conversationId,
+          `Completed ${task.type}`
+        )
+      );
+
+      return agentResult;
+    } catch (error) {
+      this.protocol.sendMessage(
+        this.protocol.createMessage(
+          this.agent.id,
+          'coordinator',
+          conversationId,
+          `Failed ${task.type}: ${(error as Error).message}`
+        )
+      );
+      throw error;
+    }
+  }
+
+  private resolveMethod(taskType: string): string {
+    switch (taskType) {
+      case 'sql.query':
+        return 'executeSQL';
+      case 'ir.retrieve':
+        return 'retrieveDocuments';
+      case 'image.process':
+        return 'processImage';
+      case 'general.answer':
+        return 'answerQuestion';
+      default:
+        throw new Error(`Unsupported task type: ${taskType}`);
+    }
+  }
+}

--- a/src/layers/llm/LLMModule.ts
+++ b/src/layers/llm/LLMModule.ts
@@ -1,0 +1,59 @@
+import { AgentResult } from '../agents/BaseAgent';
+import { RetrievedMemory, SessionContext } from '../state/StateManager';
+
+export interface LLMConfig {
+  model: string;
+  temperature?: number;
+}
+
+export class LLMModule {
+  constructor(private readonly config: LLMConfig) {}
+
+  generateResponse(prompt: string, context?: Record<string, unknown>): string {
+    const contextSummary = context ? `\nContext: ${JSON.stringify(context)}` : '';
+    return `LLM(${this.config.model}) response to: ${prompt}${contextSummary}`;
+  }
+
+  synthesize(
+    userQuery: string,
+    agentResults: AgentResult[],
+    sessionContext: SessionContext,
+    memories: RetrievedMemory[]
+  ): string {
+    const agentSections = agentResults
+      .map((result) => {
+        const serializedResult = JSON.stringify(result.result, null, 2);
+        return `### ${result.agentName}\nSummary: ${result.summary}\nDetails: ${serializedResult}`;
+      })
+      .join('\n\n');
+
+    const memorySection = memories.length
+      ? `\n\n#### Retrieved memory\n${memories
+          .map((memory) => `• (${memory.score.toFixed(2)}) ${memory.record.text}`)
+          .join('\n')}`
+      : '';
+
+    const conversationSummary = sessionContext.messages
+      .slice(-4)
+      .map((message) => `${message.role.toUpperCase()}: ${message.content}`)
+      .join('\n');
+
+    return [
+      `## User query`,
+      userQuery,
+      `\n## Conversation context`,
+      conversationSummary || 'No prior context captured for this session.',
+      `\n## Agent insights`,
+      agentSections || 'No agent results were produced.',
+      memorySection,
+      `\n## Synthesized answer`,
+      this.generateResponse(userQuery, {
+        agents: agentResults.map((result) => result.agentName),
+        memoryMatches: memories.length,
+        sessionId: sessionContext.sessionId
+      })
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+}

--- a/src/layers/protocols/A2AProtocol.ts
+++ b/src/layers/protocols/A2AProtocol.ts
@@ -1,0 +1,80 @@
+export interface AgentMessage<TPayload = unknown> {
+  id: string;
+  senderId: string;
+  recipientId: string;
+  conversationId: string;
+  content: string;
+  payload?: TPayload;
+  timestamp: number;
+}
+
+export interface AgentEnvelope<TPayload = unknown> {
+  message: AgentMessage<TPayload>;
+  status: 'queued' | 'delivered' | 'error';
+  error?: string;
+}
+
+export interface MessageQuery {
+  conversationId?: string;
+  recipientId?: string;
+  senderId?: string;
+  limit?: number;
+}
+
+export class A2AProtocol {
+  private readonly transcripts: AgentEnvelope[] = [];
+
+  sendMessage<TPayload>(message: AgentMessage<TPayload>): AgentEnvelope<TPayload> {
+    const envelope: AgentEnvelope<TPayload> = {
+      message,
+      status: 'delivered'
+    };
+
+    this.transcripts.push(envelope);
+    return envelope;
+  }
+
+  createMessage<TPayload>(
+    senderId: string,
+    recipientId: string,
+    conversationId: string,
+    content: string,
+    payload?: TPayload
+  ): AgentMessage<TPayload> {
+    return {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      senderId,
+      recipientId,
+      conversationId,
+      content,
+      payload,
+      timestamp: Date.now()
+    };
+  }
+
+  history(query?: MessageQuery): AgentEnvelope[] {
+    const results = this.transcripts.filter((envelope) => {
+      const { message } = envelope;
+
+      if (query?.conversationId && message.conversationId !== query.conversationId) {
+        return false;
+      }
+
+      if (query?.recipientId && message.recipientId !== query.recipientId) {
+        return false;
+      }
+
+      if (query?.senderId && message.senderId !== query.senderId) {
+        return false;
+      }
+
+      return true;
+    });
+
+    if (query?.limit) {
+      return results.slice(-query.limit);
+    }
+
+    return results;
+  }
+}

--- a/src/layers/protocols/MCPProtocol.ts
+++ b/src/layers/protocols/MCPProtocol.ts
@@ -1,0 +1,107 @@
+export interface JsonRpcRequest<TParams = unknown> {
+  jsonrpc: '2.0';
+  id: string;
+  method: string;
+  params?: TParams;
+}
+
+export interface JsonRpcSuccess<TResult = unknown> {
+  jsonrpc: '2.0';
+  id: string;
+  result: TResult;
+}
+
+export interface JsonRpcError {
+  jsonrpc: '2.0';
+  id: string;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export type JsonRpcResponse<TResult = unknown> =
+  | JsonRpcSuccess<TResult>
+  | JsonRpcError;
+
+export type ProcedureHandler<TParams = unknown, TResult = unknown> = (
+  params: TParams
+) => Promise<TResult> | TResult;
+
+export class MCPError extends Error {
+  constructor(message: string, public readonly code = -32000, public readonly data?: unknown) {
+    super(message);
+    this.name = 'MCPError';
+  }
+}
+
+export class MCPServer {
+  private readonly procedures = new Map<string, ProcedureHandler>();
+
+  registerProcedure<TParams, TResult>(name: string, handler: ProcedureHandler<TParams, TResult>): void {
+    this.procedures.set(name, handler as ProcedureHandler);
+  }
+
+  async handle(request: JsonRpcRequest): Promise<JsonRpcResponse> {
+    if (request.jsonrpc !== '2.0') {
+      return this.error(request.id, -32600, 'Invalid JSON-RPC version');
+    }
+
+    const handler = this.procedures.get(request.method);
+
+    if (!handler) {
+      return this.error(request.id, -32601, `Method ${request.method} not found`);
+    }
+
+    try {
+      const result = await handler(request.params);
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        result
+      };
+    } catch (error) {
+      if (error instanceof MCPError) {
+        return this.error(request.id, error.code, error.message, error.data);
+      }
+
+      return this.error(request.id, -32603, 'Internal MCP error');
+    }
+  }
+
+  private error(id: string, code: number, message: string, data?: unknown): JsonRpcError {
+    return {
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code,
+        message,
+        data
+      }
+    };
+  }
+}
+
+export class MCPClient {
+  private static idCounter = 0;
+
+  constructor(private readonly server: MCPServer, private readonly agentId: string) {}
+
+  async call<TParams, TResult>(method: string, params: TParams): Promise<TResult> {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: `${this.agentId}-${MCPClient.idCounter++}`,
+      method,
+      params
+    };
+
+    const response = await this.server.handle(request);
+
+    if ('error' in response) {
+      throw new MCPError(response.error.message, response.error.code, response.error.data);
+    }
+
+    return response.result as TResult;
+  }
+}

--- a/src/layers/state/StateManager.ts
+++ b/src/layers/state/StateManager.ts
@@ -1,0 +1,138 @@
+import crypto from 'crypto';
+
+export interface MemoryRecord {
+  id: string;
+  text: string;
+  embedding: number[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface RetrievedMemory {
+  record: MemoryRecord;
+  score: number;
+}
+
+export interface SessionMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp: number;
+}
+
+export interface SessionContext {
+  sessionId: string;
+  messages: SessionMessage[];
+  scratchpad: Record<string, unknown>;
+}
+
+class VectorDatabase {
+  private readonly records: MemoryRecord[] = [];
+
+  add(text: string, metadata?: Record<string, unknown>): MemoryRecord {
+    const embedding = this.embed(text);
+    const record: MemoryRecord = {
+      id: crypto.randomUUID(),
+      text,
+      embedding,
+      metadata
+    };
+
+    this.records.push(record);
+    return record;
+  }
+
+  search(query: string, limit = 5): RetrievedMemory[] {
+    if (!query.trim()) {
+      return [];
+    }
+
+    const queryEmbedding = this.embed(query);
+
+    return this.records
+      .map((record) => ({
+        record,
+        score: this.cosineSimilarity(queryEmbedding, record.embedding)
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+  }
+
+  private embed(text: string): number[] {
+    const cleaned = text.toLowerCase().replace(/[^a-z0-9\s]/g, ' ');
+    const tokens = cleaned.split(/\s+/).filter(Boolean);
+    const vector = new Array(64).fill(0);
+
+    tokens.forEach((token) => {
+      const digest = crypto.createHash('md5').update(token).digest();
+      const bucket = (digest[0] ?? 0) % vector.length;
+      vector[bucket] += 1;
+    });
+
+    return vector;
+  }
+
+  private cosineSimilarity(a: number[], b: number[]): number {
+    const dot = a.reduce((sum, value, index) => sum + value * (b[index] ?? 0), 0);
+    const magnitudeA = Math.sqrt(a.reduce((sum, value) => sum + value * value, 0));
+    const magnitudeB = Math.sqrt(b.reduce((sum, value) => sum + value * value, 0));
+
+    if (magnitudeA === 0 || magnitudeB === 0) {
+      return 0;
+    }
+
+    return dot / (magnitudeA * magnitudeB);
+  }
+}
+
+class ContextCache {
+  private readonly sessions = new Map<string, SessionContext>();
+
+  get(sessionId: string): SessionContext {
+    if (!this.sessions.has(sessionId)) {
+      this.sessions.set(sessionId, {
+        sessionId,
+        messages: [],
+        scratchpad: {}
+      });
+    }
+
+    return this.sessions.get(sessionId)!;
+  }
+
+  update(sessionId: string, updateFn: (context: SessionContext) => void): SessionContext {
+    const context = this.get(sessionId);
+    updateFn(context);
+    return context;
+  }
+}
+
+export class StateManager {
+  private readonly vectorDb = new VectorDatabase();
+  private readonly cache = new ContextCache();
+
+  storeMemory(text: string, metadata?: Record<string, unknown>): MemoryRecord {
+    return this.vectorDb.add(text, metadata);
+  }
+
+  recallMemories(query: string, limit = 5): RetrievedMemory[] {
+    return this.vectorDb.search(query, limit);
+  }
+
+  appendMessage(sessionId: string, message: SessionMessage): SessionContext {
+    return this.cache.update(sessionId, (context) => {
+      context.messages.push(message);
+    });
+  }
+
+  getSessionContext(sessionId: string): SessionContext {
+    return this.cache.get(sessionId);
+  }
+
+  updateScratchpad(sessionId: string, patch: Record<string, unknown>): SessionContext {
+    return this.cache.update(sessionId, (context) => {
+      context.scratchpad = {
+        ...context.scratchpad,
+        ...patch
+      };
+    });
+  }
+}

--- a/src/lib/miniExpress.ts
+++ b/src/lib/miniExpress.ts
@@ -1,0 +1,325 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { URL } from 'url';
+import fs from 'fs';
+import path from 'path';
+
+export interface RequestContext {
+  method: string;
+  url: string;
+  path: string;
+  query: Record<string, string>;
+  headers: IncomingMessage['headers'];
+  body: unknown;
+  raw: IncomingMessage;
+}
+
+export class ResponseContext {
+  private finished = false;
+
+  constructor(private readonly res: ServerResponse) {}
+
+  status(code: number): this {
+    this.res.statusCode = code;
+    return this;
+  }
+
+  json(payload: unknown): void {
+    if (this.finished) {
+      return;
+    }
+
+    this.res.setHeader('Content-Type', 'application/json');
+    this.res.end(JSON.stringify(payload));
+    this.finished = true;
+  }
+
+  send(payload: string | Buffer): void {
+    if (this.finished) {
+      return;
+    }
+
+    this.res.end(payload);
+    this.finished = true;
+  }
+
+  sendFile(filePath: string): void {
+    if (this.finished) {
+      return;
+    }
+
+    const stream = fs.createReadStream(filePath);
+    stream.on('error', () => {
+      this.status(500).send('Internal Server Error');
+    });
+
+    stream.on('open', () => {
+      this.finished = true;
+      stream.pipe(this.res);
+    });
+  }
+
+  setHeader(name: string, value: string): this {
+    this.res.setHeader(name, value);
+    return this;
+  }
+
+  isFinished(): boolean {
+    return this.finished || this.res.writableEnded;
+  }
+
+  get raw(): ServerResponse {
+    return this.res;
+  }
+}
+
+export type Middleware = (
+  req: RequestContext,
+  res: ResponseContext,
+  next: () => void
+) => void | Promise<void>;
+
+export type RouteHandler = (
+  req: RequestContext,
+  res: ResponseContext
+) => void | Promise<void>;
+
+interface Route {
+  method: string;
+  path: string;
+  handler: RouteHandler;
+}
+
+function getMimeType(filePath: string): string {
+  const ext = path.extname(filePath);
+
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'text/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+class MiniExpressApp {
+  private readonly middlewares: Middleware[] = [];
+  private readonly routes: Route[] = [];
+
+  use(middleware: Middleware): void {
+    this.middlewares.push(middleware);
+  }
+
+  get(pathname: string, handler: RouteHandler): void {
+    this.routes.push({ method: 'GET', path: pathname, handler });
+  }
+
+  post(pathname: string, handler: RouteHandler): void {
+    this.routes.push({ method: 'POST', path: pathname, handler });
+  }
+
+  listen(port: number, callback?: () => void): void {
+    const server = createServer(async (req, res) => {
+      const url = req.url ?? '/';
+      const method = req.method ?? 'GET';
+      const parsedUrl = new URL(url, 'http://localhost');
+      const requestContext: RequestContext = {
+        method,
+        url,
+        path: parsedUrl.pathname,
+        query: Object.fromEntries(parsedUrl.searchParams.entries()),
+        headers: req.headers,
+        body: undefined,
+        raw: req
+      };
+
+      const responseContext = new ResponseContext(res);
+
+      try {
+        const proceed = await this.runMiddlewares(requestContext, responseContext);
+        if (!proceed || responseContext.isFinished()) {
+          return;
+        }
+
+        const route = this.routes.find(
+          (registeredRoute) =>
+            registeredRoute.method === method &&
+            registeredRoute.path === requestContext.path
+        );
+
+        if (!route) {
+          if (!responseContext.isFinished()) {
+            responseContext.status(404).json({ error: 'Not Found' });
+          }
+          return;
+        }
+
+        await route.handler(requestContext, responseContext);
+
+        if (!responseContext.isFinished()) {
+          responseContext.send('');
+        }
+      } catch (error) {
+        if (!responseContext.isFinished()) {
+          responseContext.status(500).json({ error: 'Internal Server Error' });
+        }
+        console.error('MiniExpress encountered an error', error);
+      }
+    });
+
+    server.listen(port, callback);
+  }
+
+  private async runMiddlewares(
+    req: RequestContext,
+    res: ResponseContext
+  ): Promise<boolean> {
+    for (const middleware of this.middlewares) {
+      let nextCalled = false;
+
+      await new Promise<void>((resolve, reject) => {
+        const next = () => {
+          nextCalled = true;
+          resolve();
+        };
+
+        try {
+          const result = middleware(req, res, next);
+          if (result instanceof Promise) {
+            result
+              .then(() => {
+                if (!nextCalled) {
+                  resolve();
+                }
+              })
+              .catch(reject);
+          } else if (!nextCalled) {
+            resolve();
+          }
+        } catch (middlewareError) {
+          reject(middlewareError);
+        }
+      });
+
+      if (res.isFinished()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+function parseJsonMiddleware(): Middleware {
+  return (req, res, next) => {
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      req.body = {};
+      next();
+      return;
+    }
+
+    const chunks: string[] = [];
+    let resolved = false;
+
+    const complete = (callback: () => void) => {
+      if (!resolved) {
+        resolved = true;
+        callback();
+      }
+    };
+
+    req.raw.on('data', (chunk) => {
+      if (typeof chunk === 'string') {
+        chunks.push(chunk);
+        return;
+      }
+
+      try {
+        chunks.push((chunk as Buffer).toString('utf-8'));
+      } catch (conversionError) {
+        console.error('Failed to decode request chunk', conversionError);
+      }
+    });
+
+    req.raw.on('end', () => {
+      const rawBody = chunks.join('');
+      if (!rawBody) {
+        req.body = {};
+        complete(next);
+        return;
+      }
+
+      try {
+        req.body = JSON.parse(rawBody);
+        complete(next);
+      } catch (error) {
+        res.status(400).json({ error: 'Invalid JSON payload' });
+        complete(() => undefined);
+      }
+    });
+
+    req.raw.on('error', () => {
+      res.status(400).json({ error: 'Invalid request body' });
+      complete(() => undefined);
+    });
+  };
+}
+
+function staticMiddleware(root: string): Middleware {
+  const safeRoot = path.resolve(root);
+
+  return (req, res, next) => {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      next();
+      return;
+    }
+
+    const relativePath = req.path === '/' ? '/index.html' : req.path;
+    const candidatePath = path.join(safeRoot, relativePath);
+
+    if (!candidatePath.startsWith(safeRoot)) {
+      res.status(403).send('Forbidden');
+      return;
+    }
+
+    fs.stat(candidatePath, (error, stats) => {
+      if (error || !stats.isFile()) {
+        next();
+        return;
+      }
+
+      res.setHeader('Content-Type', getMimeType(candidatePath));
+      res.sendFile(candidatePath);
+    });
+  };
+}
+
+interface ExpressStatic {
+  (root: string): Middleware;
+}
+
+export interface MiniExpress {
+  (): MiniExpressApp;
+  json: () => Middleware;
+  static: ExpressStatic;
+}
+
+const express = (() => {
+  const factory = () => new MiniExpressApp();
+  (factory as MiniExpress).json = parseJsonMiddleware;
+  (factory as MiniExpress).static = staticMiddleware;
+  return factory as MiniExpress;
+})();
+
+export default express;

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -1,0 +1,84 @@
+declare module 'path' {
+  export function resolve(...paths: string[]): string;
+  export function join(...paths: string[]): string;
+  export function extname(path: string): string;
+}
+
+declare module 'fs' {
+  export interface Stats {
+    isFile(): boolean;
+  }
+
+  export interface ReadStream {
+    on(event: 'open', listener: () => void): this;
+    on(event: 'error', listener: (error: unknown) => void): this;
+    pipe(destination: unknown): this;
+  }
+
+  export function createReadStream(path: string): ReadStream;
+  export function stat(
+    path: string,
+    callback: (error: unknown, stats: Stats) => void
+  ): void;
+}
+
+declare module 'http' {
+  export interface IncomingMessage {
+    headers: Record<string, string | string[] | undefined>;
+    method?: string;
+    url?: string;
+    on(event: 'data', listener: (chunk: unknown) => void): this;
+    on(event: 'end', listener: () => void): this;
+    on(event: 'error', listener: (error: unknown) => void): this;
+  }
+
+  export interface ServerResponse {
+    statusCode: number;
+    writableEnded: boolean;
+    setHeader(name: string, value: string): void;
+    end(data?: unknown): void;
+    on(event: 'error', listener: (error: unknown) => void): this;
+  }
+
+  export type RequestListener = (req: IncomingMessage, res: ServerResponse) => void;
+
+  export function createServer(listener: RequestListener): {
+    listen(port: number, callback?: () => void): void;
+  };
+}
+
+declare module 'url' {
+  interface URLSearchParams {
+    entries(): IterableIterator<[string, string]>;
+  }
+
+  export class URL {
+    constructor(input: string, base?: string);
+    pathname: string;
+    searchParams: URLSearchParams;
+  }
+}
+
+declare module 'crypto' {
+  export interface Hash {
+    update(data: string): Hash;
+    digest(): Buffer;
+  }
+
+  export function randomUUID(): string;
+  export function createHash(algorithm: string): Hash;
+}
+
+declare class Buffer extends Uint8Array {
+  toString(encoding?: string): string;
+}
+
+declare const Buffer: {
+  from(data: string | ArrayBuffer | ArrayLike<number>, encoding?: string): Buffer;
+  concat(list: Buffer[]): Buffer;
+};
+
+declare var process: {
+  env: Record<string, string | undefined>;
+  cwd(): string;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "commonjs",
+    "target": "es2021",
+    "lib": ["es2021", "dom"],
+    "moduleResolution": "node",
+    "typeRoots": ["./src/types"],
+    "types": [],
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- build a TypeScript HTTP layer with an Express-compatible shim and coordinator agent that orchestrates SQL, IR, image, and general workers via A2A + MCP
- add state management, LLM synthesis, and MCP-backed agent clients for delegated tool execution
- ship a conversational UI and updated documentation explaining the AgentMaster architecture and local usage

## Testing
- tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cb004b4e64832bbe432bac34cbe9b9